### PR TITLE
Fix Cloudflare Pages build by removing custom distDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm run lint
 npm run build
 ```
 
-构建产物会输出到 `.vercel/output` 目录。
+构建产物会输出到默认的 `.next` 目录。
 
 ### Cloudflare Pages
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  distDir: ".vercel/output",
   typedRoutes: true,
   experimental: {
     optimizePackageImports: ["lucide-react"],


### PR DESCRIPTION
## Summary
- remove the custom Next.js `distDir` override so the Vercel builder can locate the routes manifest
- update the README to describe the default `.next` build output directory

## Testing
- npm run cf:deploy

------
https://chatgpt.com/codex/tasks/task_e_68e0b045a044832d9634f41da5f6637f